### PR TITLE
Variável $option não inicializada antes do foreach

### DIFF
--- a/shipping_product_2.x/install.xml
+++ b/shipping_product_2.x/install.xml
@@ -219,6 +219,7 @@
 		$this->cart->clear();
 		//Add temp itens to cart
 		foreach ($this->session->data['cacheCart'] as $product_cart){
+			$option = array();
 			foreach ($product_cart['option'] as $product_option){
 					$option[$product_option['product_option_id']]=$product_option['product_option_value_id'];
 			}


### PR DESCRIPTION
Quando tem produto no carrinho e tenta fazer o cálculo do frete na página do produto dá o erro:
`<b>Notice</b>: Undefined variable: option in <b>...`